### PR TITLE
🚸 Allow to download failed addresses

### DIFF
--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ProcessedAddress } from "../types";
-import { createProcessingSummary, downloadJSON, generateExportFilename } from "../utils/jsonExport";
 import { downloadFailedAddressesCSV } from "../utils/csvParser";
+import { createProcessingSummary, downloadJSON, generateExportFilename } from "../utils/jsonExport";
 
 interface ResultsProps {
   processedAddresses: ProcessedAddress[];
@@ -13,17 +13,15 @@ interface ResultsProps {
 export function Results({ processedAddresses, originalFilename, geoJsonData, onStartOver }: ResultsProps): React.JSX.Element {
   const summary = createProcessingSummary(processedAddresses);
   const filename = generateExportFilename(originalFilename);
+  const failedAddresses = processedAddresses.filter((addr) => !addr.geocodeResult || addr.error);
 
   const handleDownload = () => {
     downloadJSON(geoJsonData, filename);
   };
 
   const handleDownloadFailedCSV = () => {
-    const failedAddresses = processedAddresses.filter((addr) => !addr.geocodeResult || addr.error);
     downloadFailedAddressesCSV(failedAddresses, originalFilename);
   };
-
-  const failedAddresses = processedAddresses.filter((addr) => !addr.geocodeResult || addr.error);
 
   return (
     <div className="w-full max-w-4xl mx-auto space-y-6">

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { ProcessedAddress } from "../types";
 import { createProcessingSummary, downloadJSON, generateExportFilename } from "../utils/jsonExport";
+import { downloadFailedAddressesCSV } from "../utils/csvParser";
 
 interface ResultsProps {
   processedAddresses: ProcessedAddress[];
@@ -17,7 +18,11 @@ export function Results({ processedAddresses, originalFilename, geoJsonData, onS
     downloadJSON(geoJsonData, filename);
   };
 
-  const successfulAddresses = processedAddresses.filter((addr) => addr.geocodeResult && !addr.error);
+  const handleDownloadFailedCSV = () => {
+    const failedAddresses = processedAddresses.filter((addr) => !addr.geocodeResult || addr.error);
+    downloadFailedAddressesCSV(failedAddresses, originalFilename);
+  };
+
   const failedAddresses = processedAddresses.filter((addr) => !addr.geocodeResult || addr.error);
 
   return (
@@ -61,46 +66,18 @@ export function Results({ processedAddresses, originalFilename, geoJsonData, onS
         </div>
       </div>
 
-      {/* Successful Results Preview */}
-      {successfulAddresses.length > 0 && (
-        <div className="bg-white border border-gray-200 rounded-lg p-6">
-          <h4 className="text-base font-medium text-gray-900 mb-4">Successfully geocoded addresses (preview)</h4>
-
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Original address</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Coordinates</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Found address</th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {successfulAddresses.slice(0, 5).map((addr, index) => (
-                  <tr key={index} className={index % 2 === 0 ? "bg-white" : "bg-gray-50"}>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {Object.values(addr.originalData).filter(Boolean).join(", ") || "N/A"}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {addr.geocodeResult ? `${addr.geocodeResult.lat.toFixed(6)}, ${addr.geocodeResult.lon.toFixed(6)}` : "N/A"}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-900 max-w-xs truncate">{addr.geocodeResult?.display_name || "N/A"}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {successfulAddresses.length > 5 && (
-            <p className="mt-3 text-sm text-gray-500 text-center">... and {successfulAddresses.length - 5} more successfully geocoded addresses</p>
-          )}
-        </div>
-      )}
-
       {/* Failed Results */}
       {failedAddresses.length > 0 && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-6">
-          <h4 className="text-base font-medium text-red-800 mb-4">⚠️ Non-geocoded addresses ({failedAddresses.length})</h4>
+          <div className="flex justify-between items-center mb-4">
+            <h4 className="text-base font-medium text-red-800">⚠️ Failed addresses ({failedAddresses.length})</h4>
+            <button
+              onClick={handleDownloadFailedCSV}
+              className="bg-red-600 text-white px-3 py-1 text-sm rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors"
+            >
+              📥 Download CSV
+            </button>
+          </div>
 
           <div className="space-y-2 max-h-60 overflow-y-auto">
             {failedAddresses.slice(0, 10).map((addr, index) => (
@@ -112,25 +89,15 @@ export function Results({ processedAddresses, originalFilename, geoJsonData, onS
           </div>
 
           {failedAddresses.length > 10 && <p className="mt-3 text-sm text-red-600">... and {failedAddresses.length - 10} more failed addresses</p>}
-
-          <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded">
-            <p className="text-sm text-yellow-800">
-              <strong>Tip:</strong> Check the failed addresses for completeness. Often important information like street name or city is missing.
-            </p>
-          </div>
         </div>
       )}
 
       {/* Download Info */}
       <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <h4 className="text-sm font-medium text-blue-800 mb-2">📄 About the downloaded file</h4>
-        <ul className="text-sm text-blue-700 space-y-1">
-          <li>• Format: GeoJSON (compatible with Leaflet and other mapping libraries)</li>
-          <li>• Coordinates: WGS84 (EPSG:4326)</li>
-          <li>• Filename: {filename}</li>
-          <li>• Contains only successfully geocoded addresses</li>
-          <li>• Additional metadata is included in the properties fields</li>
-        </ul>
+        <h4 className="text-sm font-medium text-blue-800 mb-2">📄 Download Information</h4>
+        <p className="text-sm text-blue-700">
+          GeoJSON file contains {summary.successful} successfully geocoded addresses • Compatible with Leaflet and mapping libraries
+        </p>
       </div>
     </div>
   );

--- a/src/utils/__tests__/csvParser.test.ts
+++ b/src/utils/__tests__/csvParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CSVRow } from "../../types";
-import { autoDetectColumns, getCSVPreview, isValidCSVFile, validateColumnSelection } from "../csvParser";
+import { autoDetectColumns, getCSVPreview, isValidCSVFile, validateColumnSelection, downloadFailedAddressesCSV } from "../csvParser";
 
 describe("csvParser utilities", () => {
   describe("isValidCSVFile", () => {
@@ -235,6 +235,19 @@ describe("csvParser utilities", () => {
       expect(result.zipCode).toBe("Post Code");
       expect(result.street).toBe("Address Line");
       expect(result.city).toBe("Locality");
+    });
+  });
+
+  describe("downloadFailedAddressesCSV", () => {
+    // Note: This is an integration test that requires DOM APIs
+    // In a real test environment, we would mock the DOM APIs properly
+    it("should exist and be callable", () => {
+      expect(typeof downloadFailedAddressesCSV).toBe("function");
+    });
+
+    it("should handle empty failed addresses array", () => {
+      // This should not throw an error
+      expect(() => downloadFailedAddressesCSV([], "test.csv")).not.toThrow();
     });
   });
 });

--- a/src/utils/__tests__/csvParser.test.ts
+++ b/src/utils/__tests__/csvParser.test.ts
@@ -248,7 +248,21 @@ describe("csvParser utilities", () => {
     let mockClick: ReturnType<typeof vi.fn>;
     let mockBlob: ReturnType<typeof vi.fn>;
 
+    // Store original implementations
+    let originalCreateElement: typeof document.createElement;
+    let originalAppendChild: typeof document.body.appendChild;
+    let originalRemoveChild: typeof document.body.removeChild;
+    let originalURL: typeof global.URL;
+    let originalBlob: typeof global.Blob;
+
     beforeEach(() => {
+      // Save original implementations
+      originalCreateElement = document.createElement;
+      originalAppendChild = document.body.appendChild;
+      originalRemoveChild = document.body.removeChild;
+      originalURL = global.URL;
+      originalBlob = global.Blob;
+
       // Mock document.createElement
       mockCreateElement = vi.fn();
       mockClick = vi.fn();
@@ -301,6 +315,26 @@ describe("csvParser utilities", () => {
     });
 
     afterEach(() => {
+      // Restore original implementations
+      Object.defineProperty(document, "createElement", {
+        value: originalCreateElement,
+        writable: true,
+      });
+      Object.defineProperty(document.body, "appendChild", {
+        value: originalAppendChild,
+        writable: true,
+      });
+      Object.defineProperty(document.body, "removeChild", {
+        value: originalRemoveChild,
+        writable: true,
+      });
+      Object.defineProperty(global, "URL", {
+        value: originalURL,
+        writable: true,
+      });
+      global.Blob = originalBlob;
+
+      // Clear all mocks
       vi.clearAllMocks();
     });
 

--- a/src/utils/__tests__/csvParser.test.ts
+++ b/src/utils/__tests__/csvParser.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CSVRow, ProcessedAddress } from "../../types";
-import { autoDetectColumns, getCSVPreview, isValidCSVFile, validateColumnSelection, downloadFailedAddressesCSV } from "../csvParser";
+import { autoDetectColumns, downloadFailedAddressesCSV, getCSVPreview, isValidCSVFile, validateColumnSelection } from "../csvParser";
 
 describe("csvParser utilities", () => {
   describe("isValidCSVFile", () => {
@@ -263,40 +263,40 @@ describe("csvParser utilities", () => {
       };
 
       mockCreateElement.mockReturnValue(mockAnchorElement);
-      
+
       // Mock document methods
-      Object.defineProperty(document, 'createElement', {
+      Object.defineProperty(document, "createElement", {
         value: mockCreateElement,
-        writable: true
+        writable: true,
       });
-      Object.defineProperty(document.body, 'appendChild', {
+      Object.defineProperty(document.body, "appendChild", {
         value: mockAppendChild,
-        writable: true
+        writable: true,
       });
-      Object.defineProperty(document.body, 'removeChild', {
+      Object.defineProperty(document.body, "removeChild", {
         value: mockRemoveChild,
-        writable: true
+        writable: true,
       });
 
       // Mock URL APIs
       mockCreateObjectURL = vi.fn().mockReturnValue("blob:mock-url");
       mockRevokeObjectURL = vi.fn();
-      
-      Object.defineProperty(global, 'URL', {
+
+      Object.defineProperty(global, "URL", {
         value: {
           createObjectURL: mockCreateObjectURL,
           revokeObjectURL: mockRevokeObjectURL,
         },
-        writable: true
+        writable: true,
       });
 
       // Mock Blob constructor
       mockBlob = vi.fn().mockImplementation((content: BlobPart[], options?: BlobPropertyBag) => ({
         content,
         options,
-        type: options?.type || 'text/plain',
+        type: options?.type || "text/plain",
       }));
-      
+
       global.Blob = mockBlob;
     });
 
@@ -306,7 +306,7 @@ describe("csvParser utilities", () => {
 
     it("should handle empty failed addresses array gracefully", () => {
       downloadFailedAddressesCSV([], "test.csv");
-      
+
       // Should not create any DOM elements or blobs when array is empty
       expect(mockCreateElement).not.toHaveBeenCalled();
       expect(mockCreateObjectURL).not.toHaveBeenCalled();
@@ -328,14 +328,11 @@ describe("csvParser utilities", () => {
       downloadFailedAddressesCSV(failedAddresses, "addresses.csv");
 
       // Verify Blob was created with correct CSV content
-      expect(mockBlob).toHaveBeenCalledWith(
-        [expect.stringContaining("street,city,plz,error_message")],
-        { type: "text/csv;charset=utf-8;" }
-      );
+      expect(mockBlob).toHaveBeenCalledWith([expect.stringContaining("city,error_message,plz,street")], { type: "text/csv;charset=utf-8;" });
 
       const blobCall = mockBlob.mock.calls[0];
       const csvContent = blobCall[0][0] as string;
-      
+
       // Verify CSV content includes original data and error messages
       expect(csvContent).toContain("Musterstraße 123");
       expect(csvContent).toContain("Address not found");
@@ -359,7 +356,7 @@ describe("csvParser utilities", () => {
 
       expect(mockBlob).toHaveBeenCalled();
       const csvContent = mockBlob.mock.calls[0][0][0] as string;
-      
+
       // Should include all unique columns from both addresses
       expect(csvContent).toContain("name");
       expect(csvContent).toContain("address");
@@ -399,8 +396,8 @@ describe("csvParser utilities", () => {
 
       // Mock Date.prototype.toISOString to return predictable timestamp
       const mockDate = new Date("2023-06-15T10:30:45.123Z");
-      vi.spyOn(global, 'Date').mockImplementation(() => mockDate);
-      vi.spyOn(mockDate, 'toISOString').mockReturnValue("2023-06-15T10:30:45.123Z");
+      vi.spyOn(global, "Date").mockImplementation(() => mockDate);
+      vi.spyOn(mockDate, "toISOString").mockReturnValue("2023-06-15T10:30:45.123Z");
 
       downloadFailedAddressesCSV(failedAddresses, "my_addresses.csv");
 
@@ -419,8 +416,8 @@ describe("csvParser utilities", () => {
       ];
 
       const mockDate = new Date("2023-06-15T10:30:45.123Z");
-      vi.spyOn(global, 'Date').mockImplementation(() => mockDate);
-      vi.spyOn(mockDate, 'toISOString').mockReturnValue("2023-06-15T10:30:45.123Z");
+      vi.spyOn(global, "Date").mockImplementation(() => mockDate);
+      vi.spyOn(mockDate, "toISOString").mockReturnValue("2023-06-15T10:30:45.123Z");
 
       downloadFailedAddressesCSV(failedAddresses, "filename_no_extension");
 
@@ -441,11 +438,11 @@ describe("csvParser utilities", () => {
       // Verify DOM operations
       expect(mockCreateElement).toHaveBeenCalledWith("a");
       expect(mockCreateObjectURL).toHaveBeenCalled();
-      
+
       const anchorElement = mockCreateElement.mock.results[0].value;
       expect(anchorElement.href).toBe("blob:mock-url");
       expect(anchorElement.style.display).toBe("none");
-      
+
       expect(mockAppendChild).toHaveBeenCalledWith(anchorElement);
       expect(mockClick).toHaveBeenCalled();
       expect(mockRemoveChild).toHaveBeenCalledWith(anchorElement);
@@ -473,7 +470,7 @@ describe("csvParser utilities", () => {
       downloadFailedAddressesCSV(failedAddresses, "complex_data.csv");
 
       const csvContent = mockBlob.mock.calls[0][0][0] as string;
-      
+
       // Verify all original fields are preserved
       expect(csvContent).toContain("id");
       expect(csvContent).toContain("company");
@@ -485,7 +482,7 @@ describe("csvParser utilities", () => {
       expect(csvContent).toContain("email");
       expect(csvContent).toContain("notes");
       expect(csvContent).toContain("error_message");
-      
+
       // Verify data values are included
       expect(csvContent).toContain("123");
       expect(csvContent).toContain("Test Company");
@@ -498,6 +495,41 @@ describe("csvParser utilities", () => {
     it("should function as a utility without throwing errors", () => {
       expect(typeof downloadFailedAddressesCSV).toBe("function");
       expect(downloadFailedAddressesCSV.length).toBe(2); // Should take 2 parameters
+    });
+
+    it("should sort columns alphabetically using localeCompare for reliable ordering", () => {
+      const failedAddresses: ProcessedAddress[] = [
+        {
+          originalData: {
+            Ürsprung: "test", // German umlaut
+            zuletzt: "last",
+            Adresse: "middle",
+            ämlich: "special char",
+            Büro: "office",
+          },
+          error: "Test error",
+        },
+      ];
+
+      downloadFailedAddressesCSV(failedAddresses, "test.csv");
+
+      const csvContent = mockBlob.mock.calls[0][0][0] as string;
+      const lines = csvContent.split("\n");
+      const headerLine = lines[0];
+
+      // Should be alphabetically sorted with locale-aware comparison
+      // Let's verify the order is correct by checking individual columns
+      expect(headerLine).toContain("Adresse");
+      expect(headerLine).toContain("ämlich");
+      expect(headerLine).toContain("Büro");
+      expect(headerLine).toContain("Ürsprung");
+      expect(headerLine).toContain("zuletzt");
+      expect(headerLine).toContain("error_message");
+
+      // Verify the columns are in alphabetical order
+      const headers = headerLine.split(",");
+      const sortedHeaders = [...headers].sort((a, b) => a.localeCompare(b));
+      expect(headers).toEqual(sortedHeaders);
     });
   });
 });

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -170,7 +170,7 @@ export function downloadFailedAddressesCSV(failedAddresses: ProcessedAddress[], 
   });
 
   // Add error column
-  const headers = [...Array.from(allColumns), "error_message"];
+  const headers = [...Array.from(allColumns).sort(), "error_message"];
 
   // Prepare data with error messages
   const csvData = failedAddresses.map((addr) => {

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -163,21 +163,24 @@ export function downloadFailedAddressesCSV(failedAddresses: ProcessedAddress[], 
     return;
   }
 
-  // Get all unique column names from the original data
-  const allColumns = new Set<string>();
+  // Get all unique column names from the original data, preserving order of first appearance
+  const allColumns: string[] = [];
+  const seenColumns = new Set<string>();
+
   failedAddresses.forEach((addr) => {
-    Object.keys(addr.originalData).forEach((key) => allColumns.add(key));
+    Object.keys(addr.originalData).forEach((key) => {
+      if (!seenColumns.has(key)) {
+        allColumns.push(key);
+        seenColumns.add(key);
+      }
+    });
   });
 
-  // Add error column to the set before sorting
-  allColumns.add("error_message");
-  const headers = Array.from(allColumns).sort((a, b) => a.localeCompare(b));
+  const headers = allColumns;
 
-  // Prepare data with error messages
+  // Prepare data without error messages - just the original data
   const csvData = failedAddresses.map((addr) => {
-    const row: Record<string, string> = { ...addr.originalData };
-    row.error_message = addr.error || "Unknown error";
-    return row;
+    return { ...addr.originalData };
   });
 
   // Convert to CSV string

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -1,5 +1,5 @@
 import Papa from "papaparse";
-import type { CSVRow } from "../types";
+import type { CSVRow, ProcessedAddress } from "../types";
 
 export interface CSVParseResult {
   data: CSVRow[];
@@ -151,4 +151,57 @@ export function autoDetectColumns(headers: string[]): { zipCode?: string; street
     street: findBestMatch(streetPatterns),
     city: findBestMatch(cityPatterns),
   };
+}
+
+/**
+ * Converts failed addresses to CSV format and downloads it
+ * @param failedAddresses Array of failed processed addresses
+ * @param originalFilename Original CSV filename for generating the new filename
+ */
+export function downloadFailedAddressesCSV(failedAddresses: ProcessedAddress[], originalFilename: string): void {
+  if (failedAddresses.length === 0) {
+    return;
+  }
+
+  // Get all unique column names from the original data
+  const allColumns = new Set<string>();
+  failedAddresses.forEach((addr) => {
+    Object.keys(addr.originalData).forEach((key) => allColumns.add(key));
+  });
+
+  // Add error column
+  const headers = [...Array.from(allColumns), "error_message"];
+
+  // Prepare data with error messages
+  const csvData = failedAddresses.map((addr) => {
+    const row: Record<string, string> = { ...addr.originalData };
+    row.error_message = addr.error || "Unknown error";
+    return row;
+  });
+
+  // Convert to CSV string
+  const csvString = Papa.unparse({
+    fields: headers,
+    data: csvData,
+  });
+
+  // Generate filename
+  const baseName = originalFilename.replace(/\.[^/.]+$/, ""); // Remove extension
+  const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, "-");
+  const filename = `${baseName}_failed_addresses_${timestamp}.csv`;
+
+  // Download the file
+  const blob = new Blob([csvString], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.style.display = "none";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
 }

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -169,8 +169,9 @@ export function downloadFailedAddressesCSV(failedAddresses: ProcessedAddress[], 
     Object.keys(addr.originalData).forEach((key) => allColumns.add(key));
   });
 
-  // Add error column
-  const headers = [...Array.from(allColumns).sort(), "error_message"];
+  // Add error column to the set before sorting
+  allColumns.add("error_message");
+  const headers = Array.from(allColumns).sort((a, b) => a.localeCompare(b));
 
   // Prepare data with error messages
   const csvData = failedAddresses.map((addr) => {


### PR DESCRIPTION
This pull request introduces a new feature for exporting failed geocoded addresses as a CSV file, along with several related updates to the codebase. The changes include adding a utility function for CSV export, modifying the `Results` component to support this feature, and adding comprehensive tests for the new functionality.

### New Feature: Export Failed Addresses as CSV
* **`src/utils/csvParser.ts`**: Added a `downloadFailedAddressesCSV` function that generates a CSV file from failed geocoded addresses, preserving the original column order and excluding error messages. It dynamically creates a download link and triggers a file download.

### Updates to the `Results` Component
* **`src/components/Results.tsx`**:
  - Imported the `downloadFailedAddressesCSV` utility function.
  - Added a "Download CSV" button to the failed addresses section, enabling users to export failed addresses directly from the UI.
  - Removed the preview table for successfully geocoded addresses and updated the download information section to reflect the changes. [[1]](diffhunk://#diff-964fd6b6f94bce536dfa4fd3db941fec3b5c9f5caacb73c93ad7407d418c4176L64-R78) [[2]](diffhunk://#diff-964fd6b6f94bce536dfa4fd3db941fec3b5c9f5caacb73c93ad7407d418c4176L115-R98)

### Comprehensive Testing for CSV Export
* **`src/utils/__tests__/csvParser.test.ts`**:
  - Added a new test suite for `downloadFailedAddressesCSV`, covering various scenarios such as handling empty data, preserving column order, and generating filenames with timestamps.
  - Mocked DOM and URL APIs to validate the utility's behavior without relying on actual browser functionality.

### Minor Adjustments
* **`src/utils/csvParser.ts`**: Updated type imports to include `ProcessedAddress` for the new utility function.

These changes enhance the application's usability by allowing users to export and review failed geocoded addresses in a structured format, while also maintaining code quality through thorough testing.