### PR TITLE
💄 Improve Preview & Map View

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,28 +166,33 @@ function App(): React.JSX.Element {
 
       case "preview":
         return (
-          <div className="space-y-6 sm:space-y-8">
-            {/* Data Preview Section */}
-            <div className="space-y-4">
-              <h3 className="text-lg font-medium text-gray-900">Data Preview</h3>
-              <DataPreview data={state.csvData} headers={state.headers} />
+          <div className="space-y-6">
+            <div className="text-center">
+              <h2 className="text-xl sm:text-2xl font-bold text-gray-900 mb-2">Preview & Map Columns</h2>
+              <p className="text-gray-600">Review your data and map the address columns</p>
             </div>
 
-            {/* Column Mapping Section */}
-            <div className="space-y-4">
-              <h3 className="text-lg font-medium text-gray-900">Column Mapping</h3>
-              <ColumnSelector headers={state.headers} onMappingChange={handleMappingChange} initialMapping={state.columnMapping} />
-            </div>
+            <div className="space-y-8">
+              {/* Data Preview Section */}
+              <section className="space-y-4">
+                <DataPreview data={state.csvData} headers={state.headers} />
+              </section>
 
-            {/* Action Button */}
-            <div className="flex justify-center pt-4">
-              <button
-                onClick={handleStartProcessing}
-                className="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                disabled={!state.columnMapping.zipCode && !state.columnMapping.street && !state.columnMapping.city}
-              >
-                Start Geocoding
-              </button>
+              {/* Column Mapping Section */}
+              <section className="space-y-4">
+                <ColumnSelector headers={state.headers} onMappingChange={handleMappingChange} initialMapping={state.columnMapping} />
+              </section>
+
+              {/* Action Button */}
+              <div className="flex justify-center pt-6">
+                <button
+                  onClick={handleStartProcessing}
+                  className="bg-blue-600 text-white px-8 py-3 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200 font-medium"
+                  disabled={!state.columnMapping.zipCode && !state.columnMapping.street && !state.columnMapping.city}
+                >
+                  Start Geocoding
+                </button>
+              </div>
             </div>
           </div>
         );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,12 +174,12 @@ function App(): React.JSX.Element {
 
             <div className="space-y-8">
               {/* Data Preview Section */}
-              <section className="space-y-4">
+              <section className="space-y-4" aria-labelledby="data-preview-heading">
                 <DataPreview data={state.csvData} headers={state.headers} />
               </section>
 
               {/* Column Mapping Section */}
-              <section className="space-y-4">
+              <section className="space-y-4" aria-labelledby="address-columns-heading">
                 <ColumnSelector headers={state.headers} onMappingChange={handleMappingChange} initialMapping={state.columnMapping} />
               </section>
 

--- a/src/components/ColumnSelector.tsx
+++ b/src/components/ColumnSelector.tsx
@@ -105,7 +105,9 @@ export function ColumnSelector({ headers, onMappingChange, initialMapping }: Col
       </div>
 
       <div>
-        <h4 className="text-base font-medium text-gray-900 mb-3">Additional Data</h4>
+        <h4 id="additional-data-heading" className="text-base font-medium text-gray-900 mb-3">
+          Additional Data
+        </h4>
         <p className="text-sm text-gray-600 mb-4">Select additional columns to include in the output file.</p>
 
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">

--- a/src/components/ColumnSelector.tsx
+++ b/src/components/ColumnSelector.tsx
@@ -103,7 +103,7 @@ export function ColumnSelector({ headers, onMappingChange, initialMapping }: Col
       </div>
 
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-3">Additional Data</h3>
+        <h4 className="text-base font-medium text-gray-900 mb-3">Additional Data</h4>
         <p className="text-sm text-gray-600 mb-4">Select additional columns to include in the output file.</p>
 
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">

--- a/src/components/ColumnSelector.tsx
+++ b/src/components/ColumnSelector.tsx
@@ -39,7 +39,9 @@ export function ColumnSelector({ headers, onMappingChange, initialMapping }: Col
   return (
     <div className="w-full space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-3">Address Columns</h3>
+        <h3 id="address-columns-heading" className="text-lg font-medium text-gray-900 mb-3">
+          Address Columns
+        </h3>
         <p className="text-sm text-gray-600 mb-6">Select the columns that contain your address data. At least one column must be selected.</p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/components/ColumnSelector.tsx
+++ b/src/components/ColumnSelector.tsx
@@ -39,7 +39,7 @@ export function ColumnSelector({ headers, onMappingChange, initialMapping }: Col
   return (
     <div className="w-full space-y-6">
       <div>
-        <h3 className="text-lg font-medium text-gray-900 mb-4">Map address columns</h3>
+        <h3 className="text-lg font-medium text-gray-900 mb-3">Address Columns</h3>
         <p className="text-sm text-gray-600 mb-6">Select the columns that contain your address data. At least one column must be selected.</p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -103,7 +103,7 @@ export function ColumnSelector({ headers, onMappingChange, initialMapping }: Col
       </div>
 
       <div>
-        <h4 className="text-base font-medium text-gray-900 mb-3">Additional data (Metadata)</h4>
+        <h3 className="text-lg font-medium text-gray-900 mb-3">Additional Data</h3>
         <p className="text-sm text-gray-600 mb-4">Select additional columns to include in the output file.</p>
 
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">

--- a/src/components/DataPreview.tsx
+++ b/src/components/DataPreview.tsx
@@ -16,9 +16,7 @@ export function DataPreview({ data, headers, maxRows = 5 }: DataPreviewProps): R
 
   return (
     <div className="w-full">
-      <h3 className="text-lg font-medium text-gray-900 mb-4">
-        Data preview ({previewData.length} of {data.length} rows)
-      </h3>
+      <h3 className="text-lg font-medium text-gray-900 mb-4">Data Preview</h3>
 
       <div className="overflow-x-auto border border-gray-200 rounded-lg">
         <table className="min-w-full divide-y divide-gray-200">
@@ -45,7 +43,10 @@ export function DataPreview({ data, headers, maxRows = 5 }: DataPreviewProps): R
         </table>
       </div>
 
-      {data.length > maxRows && <p className="mt-3 text-sm text-gray-500 text-center">... and {data.length - maxRows} more rows</p>}
+      <div className="mt-3 text-sm text-gray-500 text-center">
+        Showing {previewData.length} of {data.length} rows
+        {data.length > maxRows && <span> • {data.length - maxRows} more rows available</span>}
+      </div>
     </div>
   );
 }

--- a/src/components/DataPreview.tsx
+++ b/src/components/DataPreview.tsx
@@ -16,7 +16,9 @@ export function DataPreview({ data, headers, maxRows = 5 }: DataPreviewProps): R
 
   return (
     <div className="w-full">
-      <h3 className="text-lg font-medium text-gray-900 mb-4">Data Preview</h3>
+      <h3 id="data-preview-heading" className="text-lg font-medium text-gray-900 mb-4">
+        Data Preview
+      </h3>
 
       <div className="overflow-x-auto border border-gray-200 rounded-lg">
         <table className="min-w-full divide-y divide-gray-200">

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "../../App";
 
@@ -87,6 +88,135 @@ describe("App Integration", () => {
 
       const mainHeading = screen.getByRole("heading", { level: 1 });
       expect(mainHeading).toHaveTextContent("adressli");
+    });
+  });
+
+  describe("Preview Step Accessibility", () => {
+    const mockCSVFile = new File(["name,street,zipCode,city\nJohn,Main St,12345,NYC"], "test.csv", { type: "text/csv" });
+
+    it("should have proper ARIA structure when in preview step", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Upload a file to get to preview step
+      const fileInput = screen.getByLabelText("Select CSV file");
+      await user.upload(fileInput, mockCSVFile);
+
+      // Wait for preview step to render
+      await screen.findByRole("heading", { name: "Preview & Map Columns" });
+
+      // Check main heading
+      const mainHeading = screen.getByRole("heading", { name: "Preview & Map Columns" });
+      expect(mainHeading).toBeInTheDocument();
+      expect(mainHeading.tagName).toBe("H2");
+
+      // Check sections have proper ARIA labeling - specifically look for the two preview sections
+      const dataPreviewSection = screen.getByLabelText("Data Preview");
+      expect(dataPreviewSection).toHaveAttribute("aria-labelledby", "data-preview-heading");
+
+      const addressColumnsSection = screen.getByLabelText("Address Columns");
+      expect(addressColumnsSection).toHaveAttribute("aria-labelledby", "address-columns-heading");
+    });
+
+    it("should have accessible heading hierarchy in preview step", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      const fileInput = screen.getByLabelText("Select CSV file");
+      await user.upload(fileInput, mockCSVFile);
+
+      await screen.findByRole("heading", { name: "Preview & Map Columns" });
+
+      // Check heading levels are correct
+      const h2Heading = screen.getByRole("heading", { name: "Preview & Map Columns" });
+      expect(h2Heading.tagName).toBe("H2");
+
+      const h3Headings = screen.getAllByRole("heading", { level: 3 });
+      expect(h3Headings).toHaveLength(2);
+      expect(h3Headings[0]).toHaveTextContent("Data Preview");
+      expect(h3Headings[1]).toHaveTextContent("Address Columns");
+
+      const h4Heading = screen.getByRole("heading", { name: "Additional Data" });
+      expect(h4Heading.tagName).toBe("H4");
+    });
+
+    it("should have proper IDs on section headings", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      const fileInput = screen.getByLabelText("Select CSV file");
+      await user.upload(fileInput, mockCSVFile);
+
+      await screen.findByRole("heading", { name: "Preview & Map Columns" });
+
+      // Check IDs are set correctly
+      const dataPreviewHeading = screen.getByRole("heading", { name: "Data Preview" });
+      expect(dataPreviewHeading).toHaveAttribute("id", "data-preview-heading");
+
+      const addressColumnsHeading = screen.getByRole("heading", { name: "Address Columns" });
+      expect(addressColumnsHeading).toHaveAttribute("id", "address-columns-heading");
+    });
+
+    it("should maintain semantic structure with sections", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      const fileInput = screen.getByLabelText("Select CSV file");
+      await user.upload(fileInput, mockCSVFile);
+
+      await screen.findByRole("heading", { name: "Preview & Map Columns" });
+
+      // Verify sections exist and are properly structured
+      const allSections = document.querySelectorAll("section");
+      expect(allSections.length).toBeGreaterThanOrEqual(2);
+
+      // Check that sections contain their respective content
+      const dataPreviewSection = document.querySelector('section[aria-labelledby="data-preview-heading"]');
+      expect(dataPreviewSection).toBeInTheDocument();
+      expect(dataPreviewSection).toContainElement(screen.getByRole("table"));
+
+      const addressColumnsSection = document.querySelector('section[aria-labelledby="address-columns-heading"]');
+      expect(addressColumnsSection).toBeInTheDocument();
+      expect(addressColumnsSection).toContainElement(screen.getByLabelText("ZIP Code"));
+    });
+
+    it("should have accessible form controls in preview step", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      const fileInput = screen.getByLabelText("Select CSV file");
+      await user.upload(fileInput, mockCSVFile);
+
+      await screen.findByRole("heading", { name: "Preview & Map Columns" });
+
+      // Check form labels are accessible
+      expect(screen.getByLabelText("ZIP Code")).toBeInTheDocument();
+      expect(screen.getByLabelText("Street")).toBeInTheDocument();
+      expect(screen.getByLabelText("City")).toBeInTheDocument();
+
+      // Check action button is accessible
+      const startButton = screen.getByRole("button", { name: "Start Geocoding" });
+      expect(startButton).toBeInTheDocument();
+      // Button should be enabled because auto-detection will select columns for our test CSV
+      expect(startButton).toBeEnabled();
+    });
+
+    it("should disable Start Geocoding button when no address columns are mapped", async () => {
+      const user = userEvent.setup();
+      render(<App />);
+
+      // Use a CSV with headers that won't trigger auto-detection
+      const mockCSVFileNoAutoDetect = new File(["column1,column2,column3\nvalue1,value2,value3"], "test.csv", { type: "text/csv" });
+
+      const fileInput = screen.getByLabelText("Select CSV file");
+      await user.upload(fileInput, mockCSVFileNoAutoDetect);
+
+      await screen.findByRole("heading", { name: "Preview & Map Columns" });
+
+      // Check action button is disabled when no columns are mapped
+      const startButton = screen.getByRole("button", { name: "Start Geocoding" });
+      expect(startButton).toBeInTheDocument();
+      expect(startButton).toBeDisabled();
     });
   });
 

--- a/src/components/__tests__/ColumnSelector.test.tsx
+++ b/src/components/__tests__/ColumnSelector.test.tsx
@@ -21,9 +21,10 @@ describe("ColumnSelector Component", () => {
       expect(mainHeading).toHaveAttribute("id", "address-columns-heading");
       expect(mainHeading.tagName).toBe("H3");
 
-      // Check sub-heading hierarchy
+      // Check sub-heading hierarchy and ID
       const subHeading = screen.getByRole("heading", { name: "Additional Data" });
       expect(subHeading.tagName).toBe("H4");
+      expect(subHeading).toHaveAttribute("id", "additional-data-heading");
     });
 
     it("should have accessible form labels", () => {

--- a/src/components/__tests__/ColumnSelector.test.tsx
+++ b/src/components/__tests__/ColumnSelector.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ColumnMapping } from "../../types";
+import { ColumnSelector } from "../ColumnSelector";
+
+describe("ColumnSelector Component", () => {
+  const mockHeaders = ["name", "street", "zipCode", "city", "country"];
+  const mockOnMappingChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Accessibility", () => {
+    it("should have proper heading hierarchy with IDs", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Check main heading has correct ID
+      const mainHeading = screen.getByRole("heading", { name: "Address Columns" });
+      expect(mainHeading).toHaveAttribute("id", "address-columns-heading");
+      expect(mainHeading.tagName).toBe("H3");
+
+      // Check sub-heading hierarchy
+      const subHeading = screen.getByRole("heading", { name: "Additional Data" });
+      expect(subHeading.tagName).toBe("H4");
+    });
+
+    it("should have accessible form labels", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Check that all selects have proper labels
+      expect(screen.getByLabelText("ZIP Code")).toBeInTheDocument();
+      expect(screen.getByLabelText("Street")).toBeInTheDocument();
+      expect(screen.getByLabelText("City")).toBeInTheDocument();
+    });
+
+    it("should have accessible checkboxes with descriptions", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Check that checkboxes are properly labeled
+      mockHeaders.forEach((header) => {
+        const checkbox = screen.getByRole("checkbox", { name: new RegExp(header) });
+        expect(checkbox).toBeInTheDocument();
+      });
+    });
+
+    it("should have aria-describedby for disabled checkboxes", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Select a street column first
+      const streetSelect = screen.getByLabelText("Street");
+      await user.selectOptions(streetSelect, "street");
+
+      // Check that the street checkbox is now disabled and has aria-describedby
+      const streetCheckbox = screen.getByRole("checkbox", { name: /street/ });
+      expect(streetCheckbox).toBeDisabled();
+      expect(streetCheckbox).toHaveAttribute("aria-describedby", "street-disabled");
+
+      // Check for screen reader text
+      expect(screen.getByText("(already selected as address column)")).toBeInTheDocument();
+    });
+  });
+
+  describe("Column Mapping", () => {
+    it("should render all address column selects", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      expect(screen.getByLabelText("ZIP Code")).toBeInTheDocument();
+      expect(screen.getByLabelText("Street")).toBeInTheDocument();
+      expect(screen.getByLabelText("City")).toBeInTheDocument();
+    });
+
+    it("should populate selects with headers", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Check that each select has all the options
+      const zipSelect = screen.getByLabelText("ZIP Code");
+      const streetSelect = screen.getByLabelText("Street");
+      const citySelect = screen.getByLabelText("City");
+
+      mockHeaders.forEach((header) => {
+        expect(zipSelect).toContainElement(screen.getAllByRole("option", { name: header })[0]);
+        expect(streetSelect).toContainElement(screen.getAllByRole("option", { name: header })[1]);
+        expect(citySelect).toContainElement(screen.getAllByRole("option", { name: header })[2]);
+      });
+    });
+
+    it("should call onMappingChange when address columns are selected", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      const zipSelect = screen.getByLabelText("ZIP Code");
+      await user.selectOptions(zipSelect, "zipCode");
+
+      expect(mockOnMappingChange).toHaveBeenCalledWith({
+        zipCode: "zipCode",
+        street: undefined,
+        city: undefined,
+        metadataColumns: [],
+      });
+    });
+
+    it("should use initial mapping values", () => {
+      const initialMapping: ColumnMapping = {
+        zipCode: "zipCode",
+        street: "street",
+        city: "city",
+        metadataColumns: ["name"],
+      };
+
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} initialMapping={initialMapping} />);
+
+      expect(screen.getByDisplayValue("zipCode")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("street")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("city")).toBeInTheDocument();
+    });
+  });
+
+  describe("Metadata Columns", () => {
+    it("should render metadata checkboxes for all headers", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      mockHeaders.forEach((header) => {
+        expect(screen.getByRole("checkbox", { name: new RegExp(header) })).toBeInTheDocument();
+      });
+    });
+
+    it("should toggle metadata columns", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      const nameCheckbox = screen.getByRole("checkbox", { name: /name/ });
+      await user.click(nameCheckbox);
+
+      expect(mockOnMappingChange).toHaveBeenCalledWith({
+        zipCode: undefined,
+        street: undefined,
+        city: undefined,
+        metadataColumns: ["name"],
+      });
+    });
+
+    it("should disable checkboxes for selected address columns", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Select street as address column
+      const streetSelect = screen.getByLabelText("Street");
+      await user.selectOptions(streetSelect, "street");
+
+      // Check that street checkbox is disabled
+      const streetCheckbox = screen.getByRole("checkbox", { name: /street/ });
+      expect(streetCheckbox).toBeDisabled();
+
+      // Check that the label has disabled styling
+      const streetLabel = streetCheckbox.closest("label");
+      expect(streetLabel).toHaveClass("opacity-50");
+    });
+
+    it("should show summary of selected metadata columns", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      const nameCheckbox = screen.getByRole("checkbox", { name: /name/ });
+      const countryCheckbox = screen.getByRole("checkbox", { name: /country/ });
+
+      await user.click(nameCheckbox);
+      await user.click(countryCheckbox);
+
+      expect(screen.getByText("2")).toBeInTheDocument();
+      expect(screen.getByText(/additional column\(s\) selected:/)).toBeInTheDocument();
+
+      // Check that both column names appear in the summary
+      expect(screen.getByText(/name, country/)).toBeInTheDocument();
+    });
+
+    it("should not show summary when no metadata columns selected", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      expect(screen.queryByText(/additional column\(s\) selected:/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Visual States", () => {
+    it("should apply correct styling to selected metadata columns", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      const nameCheckbox = screen.getByRole("checkbox", { name: /name/ });
+      const nameLabel = nameCheckbox.closest("label");
+
+      // Initially unselected
+      expect(nameLabel).toHaveClass("bg-white", "border-gray-300");
+
+      await user.click(nameCheckbox);
+
+      // After selection
+      expect(nameLabel).toHaveClass("bg-blue-50", "border-blue-300");
+    });
+
+    it("should apply disabled styling to address column checkboxes", async () => {
+      const user = userEvent.setup();
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      const streetSelect = screen.getByLabelText("Street");
+      await user.selectOptions(streetSelect, "street");
+
+      const streetCheckbox = screen.getByRole("checkbox", { name: /street/ });
+      const streetLabel = streetCheckbox.closest("label");
+
+      expect(streetLabel).toHaveClass("bg-gray-100", "border-gray-300", "cursor-not-allowed", "opacity-50");
+    });
+  });
+
+  describe("Semantic Structure", () => {
+    it("should have proper semantic structure with correct heading hierarchy", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Check heading hierarchy is correct
+      const h3Heading = screen.getByRole("heading", { name: "Address Columns" });
+      expect(h3Heading.tagName).toBe("H3");
+      expect(h3Heading).toHaveAttribute("id", "address-columns-heading");
+
+      const h4Heading = screen.getByRole("heading", { name: "Additional Data" });
+      expect(h4Heading.tagName).toBe("H4");
+    });
+
+    it("should provide clear instructions for users", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      expect(screen.getByText("Select the columns that contain your address data. At least one column must be selected.")).toBeInTheDocument();
+      expect(screen.getByText("Select additional columns to include in the output file.")).toBeInTheDocument();
+    });
+
+    it("should use proper form structure with labels and IDs", () => {
+      render(<ColumnSelector headers={mockHeaders} onMappingChange={mockOnMappingChange} />);
+
+      // Check that selects have proper IDs matching their labels
+      expect(screen.getByLabelText("ZIP Code")).toHaveAttribute("id", "zipcode-select");
+      expect(screen.getByLabelText("Street")).toHaveAttribute("id", "street-select");
+      expect(screen.getByLabelText("City")).toHaveAttribute("id", "city-select");
+    });
+  });
+});

--- a/src/components/__tests__/DataPreview.test.tsx
+++ b/src/components/__tests__/DataPreview.test.tsx
@@ -15,7 +15,8 @@ describe("DataPreview Component", () => {
   it("should render data preview table with headers", () => {
     render(<DataPreview data={mockData} headers={mockHeaders} />);
 
-    expect(screen.getByText("Data preview (3 of 3 rows)")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Data Preview" })).toBeInTheDocument();
+    expect(screen.getByText("Showing 3 of 3 rows")).toBeInTheDocument();
 
     // Check headers
     expect(screen.getByText("name")).toBeInTheDocument();
@@ -46,12 +47,11 @@ describe("DataPreview Component", () => {
 
     render(<DataPreview data={largeData} headers={["name", "city"]} maxRows={3} />);
 
-    expect(screen.getByText("Data preview (3 of 10 rows)")).toBeInTheDocument();
+    expect(screen.getByText("Showing 3 of 10 rows")).toBeInTheDocument();
+    expect(screen.getByText(/7.*more rows available/)).toBeInTheDocument();
     expect(screen.getByText("Person 1")).toBeInTheDocument();
     expect(screen.getByText("Person 3")).toBeInTheDocument();
     expect(screen.queryByText("Person 4")).not.toBeInTheDocument();
-
-    expect(screen.getByText("... and 7 more rows")).toBeInTheDocument();
   });
 
   it("should handle missing data values", () => {
@@ -86,8 +86,8 @@ describe("DataPreview Component", () => {
 
     render(<DataPreview data={largeData} headers={["name"]} />);
 
-    expect(screen.getByText("Data preview (5 of 8 rows)")).toBeInTheDocument();
-    expect(screen.getByText("... and 3 more rows")).toBeInTheDocument();
+    expect(screen.getByText("Showing 5 of 8 rows")).toBeInTheDocument();
+    expect(screen.getByText(/3.*more rows available/)).toBeInTheDocument();
   });
 
   it("should have proper table structure", () => {

--- a/src/components/__tests__/DataPreview.test.tsx
+++ b/src/components/__tests__/DataPreview.test.tsx
@@ -104,4 +104,48 @@ describe("DataPreview Component", () => {
     const rows = screen.getAllByRole("row");
     expect(rows).toHaveLength(4); // 1 header + 3 data rows
   });
+
+  describe("Accessibility", () => {
+    it("should have proper heading structure with ID", () => {
+      render(<DataPreview data={mockData} headers={mockHeaders} />);
+
+      const heading = screen.getByRole("heading", { name: "Data Preview" });
+      expect(heading.tagName).toBe("H3");
+      expect(heading).toHaveAttribute("id", "data-preview-heading");
+    });
+
+    it("should have accessible table structure", () => {
+      render(<DataPreview data={mockData} headers={mockHeaders} />);
+
+      const table = screen.getByRole("table");
+      expect(table).toBeInTheDocument();
+
+      // Check that headers have proper scope
+      const columnHeaders = screen.getAllByRole("columnheader");
+      columnHeaders.forEach((header) => {
+        expect(header).toHaveAttribute("scope", "col");
+      });
+    });
+
+    it("should display row information below the table", () => {
+      const largeData: CSVRow[] = Array.from({ length: 10 }, (_, i) => ({
+        name: `Person ${i + 1}`,
+        city: `City ${i + 1}`,
+      }));
+
+      render(<DataPreview data={largeData} headers={["name", "city"]} maxRows={3} />);
+
+      // Check that the additional rows message is displayed
+      expect(screen.getByText(/more rows available/)).toBeInTheDocument();
+
+      // Check that there's a section below the table with row information
+      const rowInfoDiv = document.querySelector(".mt-3.text-sm.text-gray-500.text-center");
+      expect(rowInfoDiv).toBeInTheDocument();
+
+      // Verify it contains expected information
+      expect(rowInfoDiv?.textContent).toContain("Showing");
+      expect(rowInfoDiv?.textContent).toContain("rows");
+      expect(rowInfoDiv?.textContent).toContain("more rows available");
+    });
+  });
 });


### PR DESCRIPTION
This pull request enhances the user interface for data preview and column mapping in a React application, improves accessibility and clarity of displayed information, and updates corresponding tests to reflect these changes. The most significant updates include restructuring the layout for better usability, refining text descriptions, and improving test coverage for the `DataPreview` component.

### UI Enhancements:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L169-R197): Redesigned the "Preview & Map Columns" interface by adding a title and description, grouping related sections into `<section>` elements, and updating button styles for better accessibility and consistency.

* [`src/components/ColumnSelector.tsx`](diffhunk://#diff-74c1cc09e4b73a9b982e0b073cccca41dc4ffe778ecf02cc82a348ff55ecd6b3L42-R42): Updated headings and descriptions for the column mapping interface to improve clarity and user guidance. [[1]](diffhunk://#diff-74c1cc09e4b73a9b982e0b073cccca41dc4ffe778ecf02cc82a348ff55ecd6b3L42-R42) [[2]](diffhunk://#diff-74c1cc09e4b73a9b982e0b073cccca41dc4ffe778ecf02cc82a348ff55ecd6b3L106-R106)

* [`src/components/DataPreview.tsx`](diffhunk://#diff-d1de98ec1d8b6779eda429f16617c885e4447f3e266cbd3e810b8f96207bda01L19-R19): Simplified the "Data Preview" heading and updated the footer to show a clearer summary of displayed and remaining rows. [[1]](diffhunk://#diff-d1de98ec1d8b6779eda429f16617c885e4447f3e266cbd3e810b8f96207bda01L19-R19) [[2]](diffhunk://#diff-d1de98ec1d8b6779eda429f16617c885e4447f3e266cbd3e810b8f96207bda01L48-R49)

### Test Updates:

* [`src/components/__tests__/DataPreview.test.tsx`](diffhunk://#diff-5c9d7d6e39e213a2121368b58f6fee18a09d7d02b132ecabd6b474fd5b32c2d9L18-R19): Adjusted tests for the `DataPreview` component to validate the updated headings and row summary format, ensuring alignment with the new UI changes. [[1]](diffhunk://#diff-5c9d7d6e39e213a2121368b58f6fee18a09d7d02b132ecabd6b474fd5b32c2d9L18-R19) [[2]](diffhunk://#diff-5c9d7d6e39e213a2121368b58f6fee18a09d7d02b132ecabd6b474fd5b32c2d9L49-L54) [[3]](diffhunk://#diff-5c9d7d6e39e213a2121368b58f6fee18a09d7d02b132ecabd6b474fd5b32c2d9L89-R90)