### PR TITLE
✏️ Fix project name

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 <!-- Use this file to provide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
 
-# Copilot Instructions for Adressli
+# Copilot Instructions for addressli
 
 A modern React TypeScript application for geocoding CSV address data, built with Vite and designed for non-technical users to create map-ready GeoJSON data.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Adressli
+# addressli
 
 A modern web application for geocoding CSV address data for use in mapping projects.
 
 ## Overview
 
-Adressli allows users to upload CSV files containing address data, preview the data, map address columns, and geocode them. The result is a JSON file in GeoJSON format that can be used directly in mapping libraries such as Leaflet.
+addressli allows users to upload CSV files containing address data, preview the data, map address columns, and geocode them. The result is a JSON file in GeoJSON format that can be used directly in mapping libraries such as Leaflet.
 
 ## Features
 
@@ -180,7 +180,7 @@ Coverage data is automatically uploaded to SonarCloud through the GitHub Actions
 
 ## Accessibility
 
-Adressli was developed with comprehensive accessibility in mind:
+addressli was developed with comprehensive accessibility in mind:
 
 - Keyboard navigation for all interactive elements
 - ARIA labels and semantic HTML

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,7 +255,7 @@ function App(): React.JSX.Element {
         {/* Footer */}
         <footer className="mt-6 sm:mt-8 text-center text-xs sm:text-sm text-gray-500">
           <p>
-            adressli uses OpenStreetMap Nominatim for geocoding. Please respect the{" "}
+            addressli uses OpenStreetMap Nominatim for geocoding. Please respect the{" "}
             <a
               href="https://operations.osmfoundation.org/policies/nominatim/"
               target="_blank"

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -7,7 +7,7 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({
-  title = "adressli",
+  title = "addressli",
   subtitle = "Transform your CSV address data into map-ready coordinates (GeoJSON).",
   className = "",
 }: Readonly<AppHeaderProps>): React.JSX.Element {

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -12,7 +12,7 @@ describe("App Integration", () => {
     it("should render the upload step initially", () => {
       render(<App />);
 
-      expect(screen.getByText("adressli")).toBeInTheDocument();
+      expect(screen.getByText("addressli")).toBeInTheDocument();
       expect(screen.getByText("Transform your CSV address data into map-ready coordinates (GeoJSON).")).toBeInTheDocument();
       expect(screen.getByText("Upload CSV file")).toBeInTheDocument();
     });
@@ -62,13 +62,13 @@ describe("App Integration", () => {
       render(<App />);
 
       // The app should render without crashing
-      expect(screen.getByText("adressli")).toBeInTheDocument();
+      expect(screen.getByText("addressli")).toBeInTheDocument();
     });
 
     it("should show footer with attribution", () => {
       render(<App />);
 
-      expect(screen.getByText(/adressli uses OpenStreetMap Nominatim/)).toBeInTheDocument();
+      expect(screen.getByText(/addressli uses OpenStreetMap Nominatim/)).toBeInTheDocument();
       expect(screen.getByRole("link", { name: /Nominatim Usage Policy/ })).toBeInTheDocument();
     });
   });
@@ -86,7 +86,7 @@ describe("App Integration", () => {
       render(<App />);
 
       const mainHeading = screen.getByRole("heading", { level: 1 });
-      expect(mainHeading).toHaveTextContent("adressli");
+      expect(mainHeading).toHaveTextContent("addressli");
     });
   });
 

--- a/src/components/__tests__/AppHeader.test.tsx
+++ b/src/components/__tests__/AppHeader.test.tsx
@@ -6,7 +6,7 @@ describe("AppHeader", () => {
   it("renders with default title and subtitle", () => {
     render(<AppHeader />);
 
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("🗺️adressli");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("addressli");
     expect(screen.getByText(/Transform your CSV address data into map-ready coordinates/)).toBeInTheDocument();
   });
 

--- a/src/utils/__tests__/geocoding.test.ts
+++ b/src/utils/__tests__/geocoding.test.ts
@@ -118,7 +118,7 @@ describe("geocoding utilities", () => {
         expect.stringContaining("https://nominatim.openstreetmap.org/search"),
         expect.objectContaining({
           headers: {
-            "User-Agent": "Adressli/1.0 (CSV Address Processor)",
+            "User-Agent": "addressli/1.0 (CSV Address Processor)",
           },
         })
       );

--- a/src/utils/geocoding.ts
+++ b/src/utils/geocoding.ts
@@ -24,7 +24,7 @@ export async function geocodeAddress(address: string): Promise<GeocodeResult | n
 
     const response = await fetch(`${NOMINATIM_BASE_URL}?${params}`, {
       headers: {
-        "User-Agent": "Adressli/1.0 (CSV Address Processor)",
+        "User-Agent": "addressli/1.0 (CSV Address Processor)",
       },
     });
 


### PR DESCRIPTION
This pull request standardizes the spelling of the application name from "Adressli" to "addressli" across the codebase, documentation, and tests. The changes ensure consistency in branding and user-facing text.

### Branding Updates:

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L3-R3): Updated the application name in the Copilot instructions header to "addressli" for consistency.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R7): Replaced all occurrences of "Adressli" with "addressli" in the project description, features, and accessibility sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L183-R183)

### Code Updates:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L258-R258): Updated footer text to use "addressli" instead of "adressli" for geocoding attribution.
* [`src/components/AppHeader.tsx`](diffhunk://#diff-440999d8fe6b42f60f57df9f666b96ab46580e53a5b18cb3d71863978e238929L10-R10): Changed the default `title` prop value in the `AppHeader` component to "addressli".
* [`src/utils/geocoding.ts`](diffhunk://#diff-b6c9f34f31f0e445426289fb1fad0557d09a952bc257b8bccd0637038e2a00bfL27-R27): Updated the `User-Agent` header in geocoding requests to "addressli/1.0".

### Test Updates:

* [`src/components/__tests__/App.test.tsx`](diffhunk://#diff-2b6be56aea5b16fa7d58fc5f88b73d70eb5aef0a4ee6d61e45b2af38f7a97cc7L15-R15): Replaced all test assertions referencing "adressli" with "addressli" to match the updated application name. [[1]](diffhunk://#diff-2b6be56aea5b16fa7d58fc5f88b73d70eb5aef0a4ee6d61e45b2af38f7a97cc7L15-R15) [[2]](diffhunk://#diff-2b6be56aea5b16fa7d58fc5f88b73d70eb5aef0a4ee6d61e45b2af38f7a97cc7L65-R71) [[3]](diffhunk://#diff-2b6be56aea5b16fa7d58fc5f88b73d70eb5aef0a4ee6d61e45b2af38f7a97cc7L89-R89)
* [`src/components/__tests__/AppHeader.test.tsx`](diffhunk://#diff-b2285062dc67416105338c7823b3060ecc2c05cb16cde674622924006510fe8bL9-R9): Updated the test for the default title in the `AppHeader` component to expect "addressli".
* [`src/utils/__tests__/geocoding.test.ts`](diffhunk://#diff-ca05703e2871fcd8fecc79b9f78a3f3771f0d3c24ad7727b521a8aeb1552d7b8L121-R121): Adjusted test expectations for the `User-Agent` header to use "addressli/1.0".