### PR TITLE
🚸 Improve City Name in JSON Result

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,15 +13,23 @@ export interface GeocodeResult {
   lat: number;
   lon: number;
   display_name?: string;
-  address?: {
-    postcode?: string;
-    road?: string;
-    house_number?: string;
-    city?: string;
-    town?: string;
-    village?: string;
-    country?: string;
-  };
+  address?: AddressData;
+}
+
+export interface AddressData {
+  house_number?: string;
+  road?: string;
+  quarter?: string;
+  suburb?: string;
+  city_district?: string;
+  municipality?: string;
+  city?: string;
+  town?: string;
+  village?: string;
+  state?: string;
+  postcode?: string;
+  county?: string;
+  country?: string;
 }
 
 export interface ProcessedAddress {


### PR DESCRIPTION
This pull request introduces a new utility function to extract city-related information from geocoding results, refactors the `AddressData` type for better structure, and updates related functions and tests to improve maintainability and clarity.

### Refactoring and Type Improvements:
* Replaced the inline `address` object in `GeocodeResult` with a new `AddressData` interface to better structure and expand address-related fields. (`src/types/index.ts`, [src/types/index.tsL16-L24](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476L16-L24))

### New Utility Functionality:
* Added `extractCityFromAddress` function to extract the most relevant city-related information (e.g., city, town, village) along with the postcode, if available, from an `AddressData` object. (`src/utils/jsonExport.ts`, [src/utils/jsonExport.tsL1-R34](diffhunk://#diff-eb4d68dd53fe72315317cca0aaca762e5e71cdb43ee8ce4d79604f43951c23d8L1-R34))

### Refactored Existing Code:
* Updated `constructDisplayName` to use the new `extractCityFromAddress` function for building the city part of the display name, improving code reuse and clarity. (`src/utils/jsonExport.ts`, [src/utils/jsonExport.tsL24-R53](diffhunk://#diff-eb4d68dd53fe72315317cca0aaca762e5e71cdb43ee8ce4d79604f43951c23d8L24-R53))

### Test Enhancements:
* Added comprehensive test cases for the `extractCityFromAddress` function to ensure it handles various address scenarios correctly, including fallback logic and edge cases. (`src/utils/__tests__/jsonExport.test.ts`, [src/utils/__tests__/jsonExport.test.tsR379-R455](diffhunk://#diff-72247c4375a384a0043c2d8d9a5241dac4b73c547500ccfbc18a8fa70bb848c3R379-R455))

### Import Updates:
* Updated imports in `jsonExport.test.ts` to include the new `extractCityFromAddress` function. (`src/utils/__tests__/jsonExport.test.ts`, [src/utils/__tests__/jsonExport.test.tsL3-R3](diffhunk://#diff-72247c4375a384a0043c2d8d9a5241dac4b73c547500ccfbc18a8fa70bb848c3L3-R3))